### PR TITLE
fix: remove unexpected white space above bottom tabs

### DIFF
--- a/src/app/(tabs)/library/[tab].tsx
+++ b/src/app/(tabs)/library/[tab].tsx
@@ -50,7 +50,7 @@ export default function Library() {
 		<View style={[styles.container, { backgroundColor: colors.background }]}>
 			<View
 				style={{
-					paddingBottom: 8,
+					paddingBottom: 0,
 					flex: 1,
 					paddingTop: insets.top + 8,
 				}}

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -42,7 +42,7 @@ export default function SettingsPage() {
 				style={{
 					flex: 1,
 					paddingTop: insets.top + 8,
-					paddingBottom: haveTrack ? 70 : insets.bottom,
+					paddingBottom: haveTrack ? 70 : 0,
 				}}
 			>
 				<View style={styles.header}>


### PR DESCRIPTION
native 的[底部栏](https://reactnavigation.org/docs/native-bottom-tab-navigator/)应该是已经处理过 SafeArea 了，再手动添加 `insets.bottom` 和底部边距会导致
<img width="1080" height="2424" alt="Screenshot_20251226-090539" src="https://github.com/user-attachments/assets/d7f0c729-dfc0-4960-824b-c2d737d1cf75" />

底部有这样的多余区域，修复后也不会额外遮挡元素

<img width="1080" height="2424" alt="Screenshot_20251226-090556" src="https://github.com/user-attachments/assets/399b1586-3aff-4976-9625-8db07f1cfac7" />

音乐播放时也正常

<img width="1080" height="2424" alt="Screenshot_20251226-091147" src="https://github.com/user-attachments/assets/36c44a4d-1302-47a0-a64f-938fceb8243a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 样式

* 减少了库标签页面的底部间距，优化了标题区域的视觉布局。
* 调整了设置页面的底部间距：无活跃音轨时进一步减少填充，有活跃音轨时保持原有间距。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->