### PR TITLE
fix: TypeError in FavoritePage when info is null (BBPLAYER-5N)

### DIFF
--- a/src/app/playlist/remote/favorite/[id].tsx
+++ b/src/app/playlist/remote/favorite/[id].tsx
@@ -130,6 +130,15 @@ export default function FavoritePage() {
 		)
 	}
 
+	if (!favoriteData.pages[0].info) {
+		return (
+			<PlaylistError
+				text='收藏夹信息无效或不存在'
+				onRetry={refetch}
+			/>
+		)
+	}
+
 	return (
 		<View style={[styles.container, { backgroundColor: colors.background }]}>
 			<Appbar.Header elevated>

--- a/src/types/apis/bilibili.ts
+++ b/src/types/apis/bilibili.ts
@@ -181,7 +181,7 @@ interface BilibiliFavoriteListContents {
 			face: string
 			mid: number
 		}
-	}
+	} | null
 	medias: BilibiliFavoriteListContent[] | null
 	has_more: boolean
 	ttl: number


### PR DESCRIPTION
Fixes TypeError: Cannot read property 'title' of null when Bilibili API returns null for favorite list info field.\n\n## Changes\n- Update type definition to allow null info field in BilibiliFavoriteListContents\n- Add null check to display error screen when info is null (better UX)\n- Keep UI code clean without optional chaining operators\n\n## Approach\nInstead of using optional chaining throughout the UI, we now check if info is null early and display an error screen. This provides better user experience and keeps the UI code clean.\n\nFixes BBPLAYER-5N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 增强了收藏夹加载的错误处理：当收藏夹信息无效或不存在时，会显示“收藏夹信息无效或不存在”的错误提示，并提供重试以重新拉取数据，避免在缺失信息时渲染导致的异常。

* **Chores**
  * 调整了收藏夹数据模型以支持 info 字段为空的情况，提升了对异常响应的兼容性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->