### PR TITLE
feat: add backdrop to PlayerQueueModal

### DIFF
--- a/src/components/modals/PlayerQueueModal.tsx
+++ b/src/components/modals/PlayerQueueModal.tsx
@@ -2,18 +2,23 @@ import useCurrentTrack from '@/hooks/player/useCurrentTrack'
 import usePreventRemove from '@/hooks/router/usePreventRemove'
 import { useModalStore } from '@/hooks/stores/useModalStore'
 import type { BottomSheetFlatListMethods } from '@gorhom/bottom-sheet'
-import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet'
+import BottomSheet, {
+	BottomSheetBackdrop,
+	BottomSheetFlatList,
+	useBottomSheetTimingConfigs,
+	type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet'
 import type { Track as OrpheusTrack } from '@roitium/expo-orpheus'
 import { Orpheus } from '@roitium/expo-orpheus'
 import { useQuery } from '@tanstack/react-query'
 import {
 	memo,
-	type RefObject,
 	useCallback,
 	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
+	type RefObject,
 } from 'react'
 import { View } from 'react-native'
 import {
@@ -23,6 +28,7 @@ import {
 	TouchableRipple,
 	useTheme,
 } from 'react-native-paper'
+import { Easing } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 const TrackItem = memo(
@@ -151,6 +157,23 @@ function PlayerQueueModal({
 
 	const keyExtractor = useCallback((item: OrpheusTrack) => item.id, [])
 
+	const animationConfigs = useBottomSheetTimingConfigs({
+		duration: 300,
+		easing: Easing.exp,
+	})
+
+	const renderBackdrop = useCallback(
+		(props: BottomSheetBackdropProps) => (
+			<BottomSheetBackdrop
+				{...props}
+				disappearsOnIndex={-1}
+				appearsOnIndex={0}
+				pressBehavior='close'
+			/>
+		),
+		[],
+	)
+
 	const renderItem = useCallback(
 		({ item, index }: { item: OrpheusTrack; index: number }) => (
 			<TrackItem
@@ -183,6 +206,7 @@ function PlayerQueueModal({
 			enableDynamicSizing={false}
 			enablePanDownToClose={true}
 			snapPoints={['75%']}
+			backdropComponent={renderBackdrop}
 			onChange={(index) => {
 				const nextVisible = index !== -1
 				setIsVisible(nextVisible)
@@ -200,6 +224,7 @@ function PlayerQueueModal({
 				borderBottomWidth: 1,
 				borderBottomColor: theme.colors.elevation.level5,
 			}}
+			animationConfigs={animationConfigs}
 		>
 			<View
 				style={{


### PR DESCRIPTION
之前使用播放列表的时候习惯性点击空白处，结果误入歌词界面（x
于是给播放列表上方加了遮罩，效果如下：

https://github.com/user-attachments/assets/6089ddb5-d444-469f-b287-ca26b3e651c8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 播放队列模态框现已支持自定义背景效果和改进的动画配置。
  * 优化了模态框打开/关闭时的视觉动画效果。
  * 模态框打开时自动刷新数据，关闭时重置滚动状态，提升用户体验。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->