### PR TITLE
fix: improve error message for failed lyric providers (BBPLAYER-5Q)

### DIFF
--- a/src/lib/services/lyricService.ts
+++ b/src/lib/services/lyricService.ts
@@ -96,7 +96,24 @@ class LyricService {
 			(e) => {
 				// All failed
 				// e will be an AggregateError if using Promise.any
-				return new FileSystemError('All lyric providers failed', { cause: e })
+				const aggregateError = e as AggregateError
+				const errors = Array.from(aggregateError.errors || [])
+				const errorMessages = errors
+					.map((err, index) => {
+						const providerName =
+							index === 0
+								? 'Netease'
+								: index === 1
+									? 'QQMusic'
+									: `Provider ${index}`
+						return `${providerName}: ${err instanceof Error ? err.message : String(err)}`
+					})
+					.join('; ')
+
+				return new FileSystemError(
+					`All lyric providers failed (${errors.length} providers). ${errorMessages}`,
+					{ cause: e },
+				)
 			},
 		)
 	}


### PR DESCRIPTION
## Summary

Enhanced error reporting when all lyric providers fail to fetch lyrics.

## Changes

- Modified `getBestMatchedLyrics` method in `src/lib/services/lyricService.ts`
- Improved error message to include detailed failure information from each provider
- Changed from generic "All lyric providers failed" to specific error messages showing:
  - Number of providers that failed
  - Individual error message from each provider (Netease, QQMusic, etc.)

## Problem Solved

**Issue**: BBPLAYER-5Q - "All promises were rejected" / "All lyric providers failed"

The original error message was too generic, making it difficult to debug which provider failed and why. The new error message includes detailed information about each provider's failure, making debugging much easier.

## Testing

- ✅ Lint check passed
- ✅ Pre-commit hooks passed
- 📝 Error handling logic improved with proper TypeScript types

## Related Issue

Fixes BBPLAYER-5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了歌词获取失败时的错误提示。用户现在可以看到更详细、更友好的错误信息，包括具体哪些提供商失败及失败数量。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->