### PR TITLE
fix: update PlaySlide info after song's change

### DIFF
--- a/src/hooks/player/useAnimatedTrackProgress.ts
+++ b/src/hooks/player/useAnimatedTrackProgress.ts
@@ -37,15 +37,26 @@ export default function useAnimatedTrackProgress(background = false) {
 	}, [isActive, position, duration, buffered, background])
 
 	useEffect(() => {
-		void Promise.all([
-			Orpheus.getPosition(),
-			Orpheus.getDuration(),
-			Orpheus.getBuffered(),
-		]).then(([pos, dur, buf]) => {
-			position.set(pos)
-			duration.set(dur)
-			buffered.set(buf)
-		})
+		const fetchProgress = () => {
+			void Promise.all([
+				Orpheus.getPosition(),
+				Orpheus.getDuration(),
+				Orpheus.getBuffered(),
+			]).then(([pos, dur, buf]) => {
+				position.set(pos)
+				duration.set(dur)
+				buffered.set(buf)
+			})
+		}
+
+		fetchProgress()
+
+		// 监听曲目变化，重新获取进度信息
+		const trackStartedSub = Orpheus.addListener('onTrackStarted', fetchProgress)
+
+		return () => {
+			trackStartedSub.remove()
+		}
 	}, [buffered, duration, position])
 
 	return { position, duration, buffered }


### PR DESCRIPTION
一个小 bug，暂停状态下切换歌曲时进度条不会更新，新增了一个事件监听器。

修复前：

https://github.com/user-attachments/assets/b237efbb-a0fc-4a0d-8808-99cfb5666869

修复后：

https://github.com/user-attachments/assets/bb9e7268-344e-48a5-a877-f6ce4e0007ef



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了播放器进度跟踪机制，确保在开始播放新曲目时准确更新进度信息。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->